### PR TITLE
Fix: improve class search

### DIFF
--- a/src/components/Class/Class.scss
+++ b/src/components/Class/Class.scss
@@ -15,6 +15,16 @@
 
 	background-color: var(--background-0);
 
+  transition-property: box-shadow border-color transform;
+  transition-duration: 1600ms;
+  
+  &:hover {
+    transition-duration: 400ms;
+    border-color: var(--accent-12);
+    box-shadow: var(--shadow-3);
+  }
+
+
 	&__header {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
- Return classes where search term is between minimum and maximum age or school year.
- Remove matching of ages to classes for adults where the age is over 18.